### PR TITLE
feat(admission-results): agregar lógica de creación/actualización en …

### DIFF
--- a/src/main/java/com/unsis/admunsisbackend/controller/AdminApplicantController.java
+++ b/src/main/java/com/unsis/admunsisbackend/controller/AdminApplicantController.java
@@ -1,0 +1,46 @@
+// src/main/java/com/unsis/admunsisbackend/controller/AdminApplicantController.java
+package com.unsis.admunsisbackend.controller;
+
+import com.unsis.admunsisbackend.dto.ApplicantAdminUpdateDTO;
+import com.unsis.admunsisbackend.dto.ApplicantResponseDTO;
+import com.unsis.admunsisbackend.service.ApplicantService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+@RestController
+@RequestMapping("/api/admin/applicants")
+public class AdminApplicantController {
+
+    @Autowired
+    private ApplicantService applicantService;
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<ApplicantResponseDTO> getById(@PathVariable Long id) {
+        return ResponseEntity.ok(applicantService.getApplicantById(id));
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<ApplicantResponseDTO> updateByAdmin(
+            @PathVariable Long id,
+            @RequestBody @Valid ApplicantAdminUpdateDTO dto,
+            Authentication auth) {
+
+        // Si el body trae id, validar que coincida con path
+        if (dto.getId() != null && !dto.getId().equals(id)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "El id en el body no coincide con el id de la URL");
+        }
+
+        String adminUsername = auth != null ? auth.getName() : "unknown";
+        ApplicantResponseDTO updated = applicantService.updateApplicantByAdmin(id, dto, adminUsername);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/unsis/admunsisbackend/dto/ApplicantAdminUpdateDTO.java
+++ b/src/main/java/com/unsis/admunsisbackend/dto/ApplicantAdminUpdateDTO.java
@@ -1,34 +1,62 @@
+// src/main/java/com/unsis/admunsisbackend/dto/ApplicantAdminUpdateDTO.java
 package com.unsis.admunsisbackend.dto;
+
+import com.unsis.admunsisbackend.model.ApplicantStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-public class ApplicantResponseDTO {
-
+public class ApplicantAdminUpdateDTO {
+    // opcional: puedes incluir id pero lo validamos en controller si viene
     private Long id;
+
+    @Min(1)
     private Long ficha;
+
+    // CURP: 18 caracteres alfa-numéricos (mayúsculas). Ajusta regex si necesitas
+    // reglas más estrictas.
+    @Pattern(regexp = "^[A-Z0-9]{18}$", message = "CURP inválida (18 caracteres, mayúsculas y números)")
     private String curp;
-    private String careerAtResult; 
+
+    @Size(max = 255)
     private String fullName;
+
+    @Size(max = 255)
     private String career;
+
+    @Size(max = 100)
     private String location;
+
+    @Size(max = 100)
     private String examRoom;
+
+    private Boolean examAssigned;
+
+    // ISO-8601 expected e.g. "2026-06-01T09:00:00"
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime examDate;
-    private String status;
+
+    // Usaremos enum ApplicantStatus (null = no cambiar)
+    private ApplicantStatus status;
+
+    @Min(2000)
     private Integer admissionYear;
+
+    // lastLogin en User (ISO-8601)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime lastLogin;
+
+    private String careerAtResult;
     private BigDecimal score;
-    private LocalDateTime resultDate;
 
-    public LocalDateTime getResultDate() {
-        return resultDate;
-    }
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
 
-    public void setResultDate(LocalDateTime resultDate) {
-        this.resultDate = resultDate;
-    }
-
-    // Getters y Setters
+    // getters y setters
     public Long getId() {
         return id;
     }
@@ -51,14 +79,6 @@ public class ApplicantResponseDTO {
 
     public void setCurp(String curp) {
         this.curp = curp;
-    }
-
-    public String getCareerAtResult() {
-        return careerAtResult;
-    }
-
-    public void setCareerAtResult(String careerAtResult) {
-        this.careerAtResult = careerAtResult;
     }
 
     public String getFullName() {
@@ -93,6 +113,14 @@ public class ApplicantResponseDTO {
         this.examRoom = examRoom;
     }
 
+    public Boolean getExamAssigned() {
+        return examAssigned;
+    }
+
+    public void setExamAssigned(Boolean examAssigned) {
+        this.examAssigned = examAssigned;
+    }
+
     public LocalDateTime getExamDate() {
         return examDate;
     }
@@ -101,14 +129,14 @@ public class ApplicantResponseDTO {
         this.examDate = examDate;
     }
 
-    public String getStatus() {
+    public ApplicantStatus getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(ApplicantStatus status) {
         this.status = status;
     }
-    
+
     public Integer getAdmissionYear() {
         return admissionYear;
     }
@@ -125,11 +153,27 @@ public class ApplicantResponseDTO {
         this.lastLogin = lastLogin;
     }
 
+    public String getCareerAtResult() {
+        return careerAtResult;
+    }
+
+    public void setCareerAtResult(String careerAtResult) {
+        this.careerAtResult = careerAtResult;
+    }
+
     public BigDecimal getScore() {
         return score;
     }
 
     public void setScore(BigDecimal score) {
         this.score = score;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/unsis/admunsisbackend/model/Applicant.java
+++ b/src/main/java/com/unsis/admunsisbackend/model/Applicant.java
@@ -133,4 +133,13 @@ public class Applicant {
     public void setUser(User user) {
         this.user = user;
     }
+
+    public String getCareerAtResult() {
+        return careerAtResult;
+    }
+
+    public void setCareerAtResult(String careerAtResult) {
+        this.careerAtResult = careerAtResult;
+    }
+
 }

--- a/src/main/java/com/unsis/admunsisbackend/model/ApplicantStatus.java
+++ b/src/main/java/com/unsis/admunsisbackend/model/ApplicantStatus.java
@@ -1,0 +1,7 @@
+package com.unsis.admunsisbackend.model;
+
+public enum ApplicantStatus {
+    PENDING,
+    APROBADO,
+    RECHAZADO
+}

--- a/src/main/java/com/unsis/admunsisbackend/repository/AdmissionResultRepository.java
+++ b/src/main/java/com/unsis/admunsisbackend/repository/AdmissionResultRepository.java
@@ -1,5 +1,5 @@
 package com.unsis.admunsisbackend.repository;
-    
+
 import com.unsis.admunsisbackend.model.AdmissionResult;
 import com.unsis.admunsisbackend.model.Applicant;
 import java.util.Optional;
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdmissionResultRepository extends JpaRepository<AdmissionResult, Long> {
-    //Trae el más reciente (ORDER BY createdAt DESC LIMIT 1)
+    // Trae el más reciente (ORDER BY createdAt DESC LIMIT 1)
     Optional<AdmissionResult> findTopByApplicantOrderByCreatedAtDesc(Applicant applicant);
-    
+
 }

--- a/src/main/java/com/unsis/admunsisbackend/service/ApplicantService.java
+++ b/src/main/java/com/unsis/admunsisbackend/service/ApplicantService.java
@@ -1,17 +1,23 @@
 package com.unsis.admunsisbackend.service;
 
 import com.unsis.admunsisbackend.dto.ApplicantResponseDTO;
+import com.unsis.admunsisbackend.dto.ApplicantAdminUpdateDTO;
+
 import java.util.List;
 
 public interface ApplicantService {
     List<ApplicantResponseDTO> getAllApplicants(Integer admissionYear);
-    void changeCareerByCurp(String curp, String newCareer);
-    List<ApplicantResponseDTO> searchApplicants(
-        Long ficha,
-        String curp,
-        String career,
-        String fullName
-    );
 
+    void changeCareerByCurp(String curp, String newCareer);
+
+    List<ApplicantResponseDTO> searchApplicants(
+            Long ficha,
+            String curp,
+            String career,
+            String fullName);
+
+    // ---------- Nuevos métodos para admin ----------
+    ApplicantResponseDTO getApplicantById(Long id); // GET /api/admin/applicants/{id}
+    ApplicantResponseDTO updateApplicantByAdmin(Long id, ApplicantAdminUpdateDTO dto, String adminUsername);
 
 }


### PR DESCRIPTION
…updateApplicantByAdmin

- Se agregó la capacidad de crear un nuevo AdmissionResult cuando el admin envía los campos careerAtResult, score, admissionYear o createdAt.
- Se actualiza el último AdmissionResult si el año coincide; en caso contrario, se crea un nuevo registro.
- Se añadió soporte en AdmissionResultRepository para obtener el último resultado por aspirante (findTopByApplicantOrderByCreatedAtDesc).
- Se conectó ApplicantAdminUpdateDTO con campos opcionales para actualizar resultados de admisión (careerAtResult, score, createdAt).
<img width="2164" height="1444" alt="Captura de pantalla 2025-09-05 102602" src="https://github.com/user-attachments/assets/df8a6319-0e98-4afc-a1ed-36073d87e824" />
<img width="2164" height="1444" alt="Captura de pantalla 2025-09-05 102715" src="https://github.com/user-attachments/assets/3c9a6cf6-63b3-4dac-bb31-2fe82146057a" />
