### PR TITLE
fix(auth): crear/retornar refresh token en login y corregir manejo tr…

### DIFF
--- a/src/main/java/com/unsis/admunsisbackend/dto/LoginResponse.java
+++ b/src/main/java/com/unsis/admunsisbackend/dto/LoginResponse.java
@@ -9,6 +9,8 @@ public class LoginResponse {
     private Set<String> roles;
     private String curp; // Puede ser null si no aplica
     private String token; // Aquí se va a guardar el JWT
+    private String refreshToken; // refresh token
+    private long accessTokenExpiry; // epoch ms (opcional)
 
     // Getters y setters
     public String getUsername() {
@@ -49,5 +51,21 @@ public class LoginResponse {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public long getAccessTokenExpiry() {
+        return accessTokenExpiry;
+    }
+
+    public void setAccessTokenExpiry(long accessTokenExpiry) {
+        this.accessTokenExpiry = accessTokenExpiry;
     }
 }

--- a/src/main/java/com/unsis/admunsisbackend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/unsis/admunsisbackend/security/JwtAuthenticationFilter.java
@@ -36,10 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
-    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
+    @Autowired
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, UserDetailsService userDetailsService) {
         this.tokenProvider = tokenProvider;
+        this.userDetailsService = userDetailsService;
     }
-
 
     // Método que se ejecuta para cada solicitud HTTP
     @Override

--- a/src/main/java/com/unsis/admunsisbackend/security/JwtTokenProvider.java
+++ b/src/main/java/com/unsis/admunsisbackend/security/JwtTokenProvider.java
@@ -83,4 +83,8 @@ public class JwtTokenProvider {
                 .getBody(); // esto lanzará ExpiredJwtException si expiró
     }
 
+    public int getJwtExpirationInMs() {
+        return jwtExpirationInMs;
+    }
+
 }

--- a/src/main/java/com/unsis/admunsisbackend/service/RefreshTokenService.java
+++ b/src/main/java/com/unsis/admunsisbackend/service/RefreshTokenService.java
@@ -4,6 +4,7 @@ import com.unsis.admunsisbackend.model.RefreshToken;
 import com.unsis.admunsisbackend.repository.RefreshTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // << importar
 
 import java.util.Date;
 import java.util.Optional;
@@ -11,11 +12,17 @@ import java.util.UUID;
 
 @Service
 public class RefreshTokenService {
+
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
-    // Crear un refresh token nuevo
+    // Crear un refresh token nuevo (elimina previos para el user)
+    @Transactional // << asegura que delete + save estén en una transacción
     public RefreshToken createRefreshToken(Long userId, long durationMs) {
+        // eliminar refresh tokens anteriores del usuario si quieres un sólo token
+        // activo
+        deleteByUserId(userId);
+
         RefreshToken rt = new RefreshToken();
         rt.setUserId(userId);
         rt.setToken(UUID.randomUUID().toString());
@@ -23,14 +30,18 @@ public class RefreshTokenService {
         return refreshTokenRepository.save(rt);
     }
 
+    // Buscar por token
     public Optional<RefreshToken> findByToken(String token) {
         return refreshTokenRepository.findByToken(token);
     }
 
+    // Validar si sigue vigente
     public boolean isValid(RefreshToken rt) {
-        return rt.getExpiryDate().after(new Date());
+        return rt != null && rt.getExpiryDate() != null && rt.getExpiryDate().after(new Date());
     }
 
+    // Borrar refresh tokens por userId — también transaccional
+    @Transactional
     public void deleteByUserId(Long userId) {
         refreshTokenRepository.deleteByUserId(userId);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,8 +18,8 @@ server.port=1200
 
 # JWT Configuration
 jwt.secret=MiClaveSuperSecretaJWT1234567890Seguro!
-# jwt.expiration=3600000 
-jwt.expiration=25000
+# jwt.expiration=3600000 1 min= 60000 30 seg = 30000
+jwt.expiration=60000
 
 # 1 hora en milisegundos
 


### PR DESCRIPTION
…ansaccional

- Genera y devuelve refreshToken en POST /auth/login (LoginResponse).
- Implementa create/find/isValid/delete en RefreshTokenService.
- Añade @Transactional a createRefreshToken y deleteByUserId para evitar "No EntityManager with actual transaction" en operaciones DELETE.
- Corrige /auth/refresh para rotar refresh token y devolver nuevo accessToken + refreshToken.
- Añade getter getJwtExpirationInMs en JwtTokenProvider y setAccessTokenExpiry en response.
- Corrige inyección por constructor en JwtAuthenticationFilter.
- Actualiza LoginResponse DTO con refreshToken y accessTokenExpiry.

Corrige errores que impedían refresh y evita condiciones de carrera/operaciones fuera de transacción.

<img width="2164" height="1444" alt="image" src="https://github.com/user-attachments/assets/e7ab138d-d567-48b9-ab53-be91165aeef2" />
<img width="2164" height="1444" alt="image" src="https://github.com/user-attachments/assets/463fe02b-54a7-423a-b754-e91184d1625f" />
<img width="2164" height="1444" alt="image" src="https://github.com/user-attachments/assets/40fb5334-5a04-4361-9f68-79ae79827916" />
